### PR TITLE
feat: Add ability for program to install packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ This software uses the following open source packages:
 
 ### Dependencies
 
+- [cross-spawn](https://www.npmjs.com/package/cross-spawn)
 - [js-yaml](https://www.npmjs.com/package/js-yaml)
+- [Prompts](https://www.npmjs.com/package/prompts)
 - [stringify-object](https://www.npmjs.com/package/stringify-object)
 
 ### Development Dependencies
@@ -66,7 +68,7 @@ This software uses the following open source packages:
 - [ ] Detect if ESLint isn't setup
 - [x] Support eslintrc in YAML format
 - [x] Support eslintrc in JSON format
-- [ ] Optionally auto install of Prettier and/or eslint-config-prettier
+- [x] Optionally auto install of Prettier and/or eslint-config-prettier
 - [ ] Optionally run eslint --config
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -956,6 +956,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -1154,7 +1163,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2220,8 +2228,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
@@ -2401,6 +2408,11 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
       "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "lcov-parse": {
       "version": "1.0.0",
@@ -2972,8 +2984,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -3117,6 +3128,15 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "prompts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
     },
     "psl": {
       "version": "1.8.0",
@@ -3358,7 +3378,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -3366,8 +3385,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -3388,6 +3406,11 @@
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
       }
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -3768,7 +3791,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "bin": "./cli.js",
   "scripts": {
-    "test": "mocha tests/**/*.test.js",
+    "test": "mocha tests/**/*.test.js tests/*.test.js",
     "coverage": "nyc --reporter=html --reporter=text npm test",
     "coveralls": "NODE_ENV=test nyc --reporter=text-lcov npm test | coveralls",
     "view-nyc-report": "npm run coverage && open coverage/index.html",
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/brainomite/auto-config-eslint-for-prettier#readme",
   "devDependencies": {
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "coveralls": "^3.1.0",
     "eslint": "^7.19.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -48,7 +49,9 @@
     "sinon": "^9.2.4"
   },
   "dependencies": {
+    "cross-spawn": "^7.0.3",
     "js-yaml": "^4.0.0",
+    "prompts": "^2.4.0",
     "stringify-object": "^3.3.0"
   }
 }

--- a/src/init.js
+++ b/src/init.js
@@ -8,7 +8,7 @@ function init() {
 
   const eslintrcObj = initFns.getEslintObj(eslintrcPath);
 
-  const devDependenciesArr = initFns.getStrArrayOfDevDependencies();
+  const devDependenciesArr = initFns.getStrArrayOfDependencies();
   const extendsToAddArr = initFns.getExtendsAdditionStrArr(devDependenciesArr);
   const newEslintrcFileObj = initFns.addPrettierToConfig(
     eslintrcObj,

--- a/src/init.js
+++ b/src/init.js
@@ -3,13 +3,21 @@ const initFns = require("./initFns");
 /**
  * main function
  */
-function init() {
+async function init() {
   const eslintrcPath = initFns.getEslintrcPathStr();
 
   const eslintrcObj = initFns.getEslintObj(eslintrcPath);
 
-  const devDependenciesArr = initFns.getStrArrayOfDependencies();
-  const extendsToAddArr = initFns.getExtendsAdditionStrArr(devDependenciesArr);
+  const dependenciesArr = initFns.getStrArrayOfDependencies();
+  const extendsToAddArr = initFns.getExtendsAdditionStrArr(dependenciesArr);
+  try {
+    await initFns.installPrettierExtensions(dependenciesArr);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log("Oops! Something went wrong! :(");
+    process.exit(1);
+  }
+
   const newEslintrcFileObj = initFns.addPrettierToConfig(
     eslintrcObj,
     extendsToAddArr

--- a/src/initFns/findMissingDependencies.js
+++ b/src/initFns/findMissingDependencies.js
@@ -1,0 +1,17 @@
+const REQUIRED_DEPENDENCIES = ["eslint", "prettier", "eslint-config-prettier"];
+
+/**
+ * determines if eslint, prettier, or eslint-config-prettier is missing
+ *
+ * @param {string[]} dependencyStrArray array of dependencies already in package.json
+ * @returns {string[]} array of packages not found
+ */
+function findMissingDependencies(dependencyStrArray) {
+  return REQUIRED_DEPENDENCIES.filter(
+    (dependency) => !dependencyStrArray.includes(dependency)
+  );
+}
+
+module.exports = {
+  findMissingDependencies,
+};

--- a/src/initFns/getStrArrayOfDependencies.js
+++ b/src/initFns/getStrArrayOfDependencies.js
@@ -6,15 +6,15 @@ const fs = require("fs");
  *
  * @returns {string[]} array of dev dependencies
  */
-function getStrArrayOfDevDependencies() {
+function getStrArrayOfDependencies() {
   const packageJsonPathStr = path.resolve("./", "package.json");
   const projectJson = fs.readFileSync(packageJsonPathStr, {
     encoding: "utf-8",
   });
   const projectJsObj = JSON.parse(projectJson);
 
-  const { devDependencies = {} } = projectJsObj;
-  return Object.keys(devDependencies);
+  const { devDependencies = {}, dependencies = {} } = projectJsObj;
+  return [...Object.keys(devDependencies), ...Object.keys(dependencies)];
 }
 
-module.exports = { getStrArrayOfDevDependencies };
+module.exports = { getStrArrayOfDependencies };

--- a/src/initFns/index.js
+++ b/src/initFns/index.js
@@ -1,7 +1,5 @@
 const { addPrettierToConfig } = require("./addPrettierToConfig");
-const {
-  getStrArrayOfDevDependencies,
-} = require("./getStrArrayOfDevDependencies");
+const { getStrArrayOfDependencies } = require("./getStrArrayOfDependencies");
 const { getExtendsAdditionStrArr } = require("./getExtendsAdditionStrArr");
 const { writeEslintrcFile } = require("./writeEslintrcFile.js");
 const { getEslintObj } = require("./getEslintObj");
@@ -9,7 +7,7 @@ const { getEslintrcPathStr } = require("./getEslintrcPathStr");
 
 module.exports = {
   addPrettierToConfig,
-  getStrArrayOfDevDependencies,
+  getStrArrayOfDependencies,
   getExtendsAdditionStrArr,
   writeEslintrcFile,
   getEslintObj,

--- a/src/initFns/index.js
+++ b/src/initFns/index.js
@@ -4,6 +4,8 @@ const { getExtendsAdditionStrArr } = require("./getExtendsAdditionStrArr");
 const { writeEslintrcFile } = require("./writeEslintrcFile.js");
 const { getEslintObj } = require("./getEslintObj");
 const { getEslintrcPathStr } = require("./getEslintrcPathStr");
+const { findMissingDependencies } = require("./findMissingDependencies");
+const { installPrettierExtensions } = require("./installPrettierExtensions");
 
 module.exports = {
   addPrettierToConfig,
@@ -12,4 +14,6 @@ module.exports = {
   writeEslintrcFile,
   getEslintObj,
   getEslintrcPathStr,
+  findMissingDependencies,
+  installPrettierExtensions,
 };

--- a/src/initFns/installPrettierExtensions.js
+++ b/src/initFns/installPrettierExtensions.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-console */
+const spawn = require("cross-spawn");
+const prompts = require("prompts");
+
+const PRETTIER_PACKAGES = ["prettier", "eslint-plugin-prettier"];
+
+/**
+ * this will attempt, with the user's permission to install the missing
+ * dependencies using npm
+ *
+ * @param {string[]} missingDependenciesArr arr of dependencies to install
+ * @returns {undefined} always returns undefined
+ */
+async function installPrettierExtensions(missingDependenciesArr) {
+  const packagesToInstallArr = PRETTIER_PACKAGES.filter(
+    (dependency) => !missingDependenciesArr.includes(dependency)
+  );
+
+  if (!packagesToInstallArr.length) return undefined;
+  const packageStr = packagesToInstallArr.join(" ");
+  const message = `The following packages are missing: ${packageStr}. OK to Install?`;
+  const { value: okToProceedStr } = await prompts({
+    type: "toggle",
+    name: "value",
+    message,
+    initial: true,
+    active: "Yes",
+    inactive: "no",
+  });
+  const pluralS = packagesToInstallArr.length > 1 ? "s" : "";
+  if (!okToProceedStr) {
+    console.info(
+      `Packages not installed. Please install the following package${pluralS} with a package manager of your choice: ${packageStr}`
+    );
+    return undefined;
+  }
+  const result = spawn.sync("npm", ["i", "-D", ...packagesToInstallArr], {
+    stdio: "inherit",
+  });
+  if (result.error && result.error.code === "ENOENT") {
+    console.error(
+      `Could not execute npm. Please install the following package${pluralS} with a package manager of your choice: ${packageStr}`
+    );
+  }
+  return undefined;
+}
+
+module.exports = {
+  installPrettierExtensions,
+};

--- a/tests/initFns/findMissingDependencies.test.js
+++ b/tests/initFns/findMissingDependencies.test.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-undef */
+const { expect } = require("chai");
+const {
+  findMissingDependencies,
+} = require("../../src/initFns/findMissingDependencies");
+
+describe("findMissingDependencies", () => {
+  it("returns an array of missing packages for prettier", () => {
+    const dependencies = [];
+    const expected = ["eslint", "prettier", "eslint-config-prettier"];
+    const actual = findMissingDependencies(dependencies);
+
+    expect(actual).to.eql(expected);
+  });
+  it("returns an array of missing packages for prettier, selectively", () => {
+    const dependencies = ["prettier"];
+    const expected = ["eslint", "eslint-config-prettier"];
+    const actual = findMissingDependencies(dependencies);
+
+    expect(actual).to.eql(expected);
+  });
+});

--- a/tests/initFns/getStrArrayOfDependencies.test.js
+++ b/tests/initFns/getStrArrayOfDependencies.test.js
@@ -4,10 +4,10 @@ const sinon = require("sinon");
 const fs = require("fs");
 
 const {
-  getStrArrayOfDevDependencies,
-} = require("../../src/initFns/getStrArrayOfDevDependencies");
+  getStrArrayOfDependencies,
+} = require("../../src/initFns/getStrArrayOfDependencies");
 
-describe("getArrayOfDevDependencies", () => {
+describe("getArrayOfDependencies", () => {
   let readFileSyncStub = sinon.stub;
   beforeEach(() => {
     readFileSyncStub = sinon.stub(fs, "readFileSync");
@@ -22,6 +22,8 @@ describe("getArrayOfDevDependencies", () => {
       "mocha",
       "prettier",
       "sinon",
+      "prompts",
+      "stringify-object",
     ];
     readFileSyncStub.returns(`{
       "name": "auto-config-eslint-for-prettier",
@@ -63,13 +65,13 @@ describe("getArrayOfDevDependencies", () => {
         "stringify-object": "^3.3.0"
       }
     }`);
-    const actual = getStrArrayOfDevDependencies();
+    const actual = getStrArrayOfDependencies();
     expect(actual.sort()).to.eql(expected.sort());
   });
-  it("Handle if there is no devDependencies key", () => {
+  it("Handle if there is no dependencies key", () => {
     readFileSyncStub.returns("{}");
     const expected = [];
-    const actual = getStrArrayOfDevDependencies();
+    const actual = getStrArrayOfDependencies();
     expect(actual).to.eql(expected);
   });
 });

--- a/tests/initFns/installPrettierExtensions.test.js
+++ b/tests/initFns/installPrettierExtensions.test.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-undef */
+const { expect } = require("chai");
+const sinon = require("sinon");
+const prompts = require("prompts");
+const spawn = require("cross-spawn");
+const {
+  installPrettierExtensions,
+} = require("../../src/initFns/installPrettierExtensions");
+
+describe("installPrettierExtensions", () => {
+  let syncStub = sinon.stub();
+  let errorStub = sinon.stub();
+  let infoStub = sinon.stub();
+  beforeEach(() => {
+    infoStub = sinon.stub(console, "info");
+    errorStub = sinon.stub(console, "error");
+    syncStub = sinon.stub(spawn, "sync");
+  });
+  afterEach(() => {
+    infoStub.restore();
+    errorStub.restore();
+    syncStub.restore();
+  });
+  it("doesn't invoke anything when passed in array is empty", async () => {
+    const expected = false;
+
+    await installPrettierExtensions([
+      "eslint",
+      "prettier",
+      "eslint-plugin-prettier",
+    ]);
+    const actual = syncStub.called;
+
+    expect(actual).to.equal(expected);
+  });
+  it("only installs prettier extensions", async () => {
+    const expected = [
+      "npm",
+      ["i", "-D", "prettier", "eslint-plugin-prettier"],
+      { stdio: "inherit" },
+    ];
+    syncStub.returns({});
+    prompts.inject([true]);
+
+    await installPrettierExtensions([]);
+    const actual = syncStub.firstCall.args;
+
+    expect(actual).to.deep.eql(expected);
+  });
+  it("When answer is not Yes, don't install and send message to user", async () => {
+    prompts.inject([false]);
+    const extensions = [];
+
+    await installPrettierExtensions(extensions);
+    let expected = false;
+    let actual = syncStub.called;
+    expect(actual).to.equal(expected);
+    expected =
+      "Packages not installed. Please install the following packages with a package manager of your choice: prettier eslint-plugin-prettier";
+    actual = infoStub.firstCall.firstArg;
+    expect(actual).to.equal(expected);
+  });
+  it("When 'npm i' fails, let user know", async () => {
+    prompts.inject([true]);
+    const extensions = ["prettier"];
+    const expected =
+      "Could not execute npm. Please install the following package with a package manager of your choice: eslint-plugin-prettier";
+    syncStub.returns({ error: { code: "ENOENT" } });
+    await installPrettierExtensions(extensions);
+    const actual = errorStub.firstCall.firstArg;
+    expect(actual).to.equal(expected);
+  });
+});


### PR DESCRIPTION
prettier and eslint-plugin-prettier are required packages

- tests:
   - create tests for findMissingDependencies
   - create tests for installPrettierExtensions
- new functions:
   - findMissingDependencies
   - installPrettierExtensions
- docs:
   - update README with new dependencies
- packages added:
   - prompts - adds ability to prompt the user
   - cross-spawn - adds ability to run cli commands and share all outputs
- function rewrite
   - transformed getStrArrayOfDevDependencies into getStrArrayOfDependencies